### PR TITLE
update line-pay package version

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.1
-line-pay==0.0.1
+line-pay==0.1.0
 requests==2.22.0
 python-dotenv==0.10.3


### PR DESCRIPTION
line-pay パッケージを01.0にあげないと決済後にAPIヘッダーエラーになったので、一応プルリク投げてみました。ただプルリク3年ぶりくらいなので投げ方やコードが変だったらリジェクトしてください(^^;)笑