### PR TITLE
get error code 1124 if refund_amount is float

### DIFF
--- a/linepay/api.py
+++ b/linepay/api.py
@@ -273,7 +273,7 @@ class LinePayApi(object):
             )
 
     @validate_function_args_return_value
-    def refund(self, transaction_id: int, refund_amount: float = 0.0) -> dict:
+    def refund(self, transaction_id: int, refund_amount: int = 0) -> dict:
         """Method to Refund Payment
         :param int transaction_id: Transaction id returned from Request API
         :param float refund_amount: Refund amount. Full refund if not returned


### PR DESCRIPTION
When we were using the Refund API, we found that according to the method refund() of your api.py, the refund_amout of the type float was passed, and we received a Line return error: **{'returnCode': '1124','returnMessage': 'Error in Amount info.'}**.
After confirmation, it is found that the refundAmount needs to return integer data